### PR TITLE
Serve content types, else redirect.

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -30,7 +30,7 @@ class GlobalConfig(BaseConfig):
     google_api_key: str = os.environ.get("GOOGLE_API_KEY")
     mnemonichq_api_key: str = os.environ.get("MNEMONICHQ_API_KEY")
     camo_key: str = os.environ.get("CAMO_KEY")
-    domain: str = os.environ.get("DOMAIN")
+    domain: str = os.environ.get("DOMAIN") if not os.environ.get("DOMAIN").endswith("/") else os.environ.get("DOMAIN")[:-1]
     tags_metadata: dict = [
         {
             "name": "Wallet Addresses",

--- a/middleware.py
+++ b/middleware.py
@@ -6,11 +6,14 @@ class LowerCaseMiddleware:
         self.DECODE_FORMAT = "latin-1"
 
     async def __call__(self, request: Request, call_next):
-        raw = request.scope["query_string"].decode(self.DECODE_FORMAT).lower()
-        request.scope["query_string"] = raw.encode(self.DECODE_FORMAT)
-
-        path = request.scope["path"].lower()
-        request.scope["path"] = path
+        # print(request.scope)
+        path = request.scope["path"]
+        if not path.startswith('/url'):
+            # Makes query string lowercase
+            raw = request.scope["query_string"].decode(self.DECODE_FORMAT).lower()
+            request.scope["query_string"] = raw.encode(self.DECODE_FORMAT)
+            # Makes path lowercase
+            request.scope["path"] = path.lower()
 
         response = await call_next(request)
         return response


### PR DESCRIPTION
- fixes extra slashes in `DOMAIN` for .env
- bypass lowercase middleware for `/url` routes
- serve content from fastapi if possible, else redirect.